### PR TITLE
Update tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,8 @@ find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 set(FORMS
         src/TileDataUI.ui
-        src/TileSetDataUI.ui)
+        src/TileSetDataUI.ui
+        src/ItemSelectionUI.ui)
 
 set(SOURCES
         src/main.cxx

--- a/src/ItemSelectionUI.ui
+++ b/src/ItemSelectionUI.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <author>Lisa</author>
+ <class>ItemSelectionUI</class>
+ <widget class="QWidget" name="ItemSelectionUI">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>402</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ItemSelectionUI</string>
+  </property>
+  <widget class="QWidget" name="gridLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>381</width>
+     <height>281</height>
+    </rect>
+   </property>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="listOfLabel">
+      <property name="text">
+       <string>List of</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="8">
+     <widget class="QLabel" name="usedLabel">
+      <property name="text">
+       <string>Used</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1" colspan="3">
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="removeItemButton">
+        <property name="text">
+         <string>&lt;&lt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="useItemButton">
+        <property name="text">
+         <string>&gt;&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="clearButton">
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </item>
+    <item row="1" column="8">
+     <widget class="QListWidget" name="usedItems"/>
+    </item>
+    <item row="1" column="0">
+     <widget class="QListWidget" name="availableItems"/>
+    </item>
+    <item row="4" column="8">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QPushButton" name="cancelButton">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="okButton">
+        <property name="text">
+         <string>OK</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ItemSelectionUI.ui
+++ b/src/ItemSelectionUI.ui
@@ -54,7 +54,7 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="pushButton">
+       <widget class="QPushButton" name="addAllButton">
         <property name="text">
          <string>All</string>
         </property>

--- a/src/ItemSelectionUI.ui
+++ b/src/ItemSelectionUI.ui
@@ -54,6 +54,13 @@
        </spacer>
       </item>
       <item>
+       <widget class="QPushButton" name="pushButton">
+        <property name="text">
+         <string>All</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QPushButton" name="removeItemButton">
         <property name="text">
          <string>&lt;&lt;</string>

--- a/src/TileDataContainer.cxx
+++ b/src/TileDataContainer.cxx
@@ -12,323 +12,323 @@ bool TileDataContainer::hasTileData(const QString& id) const { return tileData.c
 
 TileData TileDataContainer::getTileData(const QString& id) const
 {
-	if (!tileData.contains(id))
-		return TileData();
+  if (!tileData.contains(id))
+    return TileData();
 
-	return tileData[id];
+  return tileData[id];
 }
 
 //--------------------------------------------------------------------------------
 
 QString TileDataContainer::loadFile(const QString& theFileName)
 {
-	fileName = theFileName;
-	tileData.clear();
+  fileName = theFileName;
+  tileData.clear();
 
-	QFile file(fileName);
-	if (!file.exists())
-		return QString();
+  QFile file(fileName);
+  if (!file.exists())
+    return QString();
 
-	if (!file.open(QIODevice::ReadOnly))
-		return file.errorString();
+  if (!file.open(QIODevice::ReadOnly))
+    return file.errorString();
 
-	QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
-	if (doc.isNull() || !doc.isArray())
-		return tr("Illegal file content");
+  QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+  if (doc.isNull() || !doc.isArray())
+    return tr("Illegal file content");
 
-	for (const QJsonValue& value : doc.array())
-	{
-		QJsonObject obj = value.toObject();
+  for (const QJsonValue& value : doc.array())
+  {
+    QJsonObject obj = value.toObject();
 
-		TileData tile;
-		QString id = obj.value("id").toString();
-		tile.id = id.toStdString();
-		tile.category = obj.value("category").toString().toStdString();
-		tile.subCategory = obj.value("subCategory").toString().toStdString();
-		tile.title = obj.value("title").toString().toStdString();
-		tile.description = obj.value("description").toString().toStdString();
-		tile.author = obj.value("author").toString().toStdString();
-		tile.price = obj.value("price").toInt();
-		tile.upkeepCost = obj.value("upkeep cost").toInt();
-		tile.power = obj.value("power").toInt();
-		tile.water = obj.value("water").toInt();
-		tile.inhabitants = obj.value("inhabitants").toInt();
-		tile.pollutionLevel = obj.value("pollutionLevel").toInt();
-		tile.happiness = obj.value("happiness").toInt();
-		tile.fireHazardLevel = obj.value("fireHazardLevel").toInt();
-		tile.educationLevel = obj.value("educationLevel").toInt();
-		tile.crimeLevel = obj.value("crimeLevel").toInt();
-		tile.isOverPlacable = obj.value("isOverPlacable").toBool();
-		tile.placeOnWater = obj.value("placeOnWater").toBool();
+    TileData tile;
+    QString id = obj.value("id").toString();
+    tile.id = id.toStdString();
+    tile.category = obj.value("category").toString().toStdString();
+    tile.subCategory = obj.value("subCategory").toString().toStdString();
+    tile.title = obj.value("title").toString().toStdString();
+    tile.description = obj.value("description").toString().toStdString();
+    tile.author = obj.value("author").toString().toStdString();
+    tile.price = obj.value("price").toInt();
+    tile.upkeepCost = obj.value("upkeep cost").toInt();
+    tile.power = obj.value("power").toInt();
+    tile.water = obj.value("water").toInt();
+    tile.inhabitants = obj.value("inhabitants").toInt();
+    tile.pollutionLevel = obj.value("pollutionLevel").toInt();
+    tile.happiness = obj.value("happiness").toInt();
+    tile.fireHazardLevel = obj.value("fireHazardLevel").toInt();
+    tile.educationLevel = obj.value("educationLevel").toInt();
+    tile.crimeLevel = obj.value("crimeLevel").toInt();
+    tile.isOverPlacable = obj.value("isOverPlacable").toBool();
+    tile.placeOnWater = obj.value("placeOnWater").toBool();
 
-		// Place on ground should default to true, if not explictly set to false
-		if (obj.value("placeOnGround").isUndefined())
-		{
-			tile.placeOnGround = true;
-		}
-		else
-		{
-			tile.placeOnGround = obj.value("placeOnGround").toBool();
-		}
+    // Place on ground should default to true, if not explictly set to false
+    if (obj.value("placeOnGround").isUndefined())
+    {
+      tile.placeOnGround = true;
+    }
+    else
+    {
+      tile.placeOnGround = obj.value("placeOnGround").toBool();
+    }
 
-		tileTypeFromJson(tile.tileType, obj.value("tileType"));
-		requiredTilesFromJson(tile.RequiredTiles, obj.value("RequiredTiles"));
+    tileTypeFromJson(tile.tileType, obj.value("tileType"));
+    requiredTilesFromJson(tile.RequiredTiles, obj.value("RequiredTiles"));
 
-		stringArrayFromJson(tile.tags, obj.value("tags"));
-		stringArrayFromJson(tile.biomes, obj.value("biomes"));
-		stringArrayFromJson(tile.groundDecoration, obj.value("groundDecoration"));
-		zonesFromJson(tile.zones, obj.value("zones"));
-		stylesFromJson(tile, obj.value("style"));
-		wealthFromJson(tile, obj.value("wealth"));
+    stringArrayFromJson(tile.tags, obj.value("tags"));
+    stringArrayFromJson(tile.biomes, obj.value("biomes"));
+    stringArrayFromJson(tile.groundDecoration, obj.value("groundDecoration"));
+    zonesFromJson(tile.zones, obj.value("zones"));
+    stylesFromJson(tile, obj.value("style"));
+    wealthFromJson(tile, obj.value("wealth"));
 
-		tileSetDataFromJson(tile.tiles, obj.value("tiles"));
-		tileSetDataFromJson(tile.shoreTiles, obj.value("shoreLine"));
-		tileSetDataFromJson(tile.slopeTiles, obj.value("slopeTiles"));
+    tileSetDataFromJson(tile.tiles, obj.value("tiles"));
+    tileSetDataFromJson(tile.shoreTiles, obj.value("shoreLine"));
+    tileSetDataFromJson(tile.slopeTiles, obj.value("slopeTiles"));
 
-		tileData.insert(id, tile);
-	}
+    tileData.insert(id, tile);
+  }
 
-	return QString();
+  return QString();
 }
 
 //--------------------------------------------------------------------------------
 
 void TileDataContainer::tileSetDataFromJson(TileSetData& data, const QJsonValue& value)
 {
-	QJsonObject obj = value.toObject();
+  QJsonObject obj = value.toObject();
 
-	data.fileName = obj.value("fileName").toString().toStdString();
-	data.count = obj.value("count").toInt();
-	data.clippingWidth = obj.value("clip_width").toInt();
-	data.clippingHeight = obj.value("clip_height").toInt();
-	data.offset = obj.value("offset").toInt();
-	if (obj.value("pickRandomTile").isUndefined())
-	{
-		if (data.count > 1)
-		{
-			data.pickRandomTile = true;
-		}
-		else
-		{
-			data.pickRandomTile = false;
-		}
-	}
-	else
-	{
-		data.pickRandomTile = obj.value("pickRandomTile").toBool();
-	}
+  data.fileName = obj.value("fileName").toString().toStdString();
+  data.count = obj.value("count").toInt();
+  data.clippingWidth = obj.value("clip_width").toInt();
+  data.clippingHeight = obj.value("clip_height").toInt();
+  data.offset = obj.value("offset").toInt();
+  if (obj.value("pickRandomTile").isUndefined())
+  {
+    if (data.count > 1)
+    {
+      data.pickRandomTile = true;
+    }
+    else
+    {
+      data.pickRandomTile = false;
+    }
+  }
+  else
+  {
+    data.pickRandomTile = obj.value("pickRandomTile").toBool();
+  }
 }
 
 void TileDataContainer::requiredTilesFromJson(RequiredTilesData& data, const QJsonValue& value)
 {
-	QJsonObject obj = value.toObject();
+  QJsonObject obj = value.toObject();
 
-	data.width = static_cast<unsigned int>(obj.value("width").toInt());
-	data.height= static_cast<unsigned int>(obj.value("height").toInt());
+  data.width = static_cast<unsigned int>(obj.value("width").toInt());
+  data.height = static_cast<unsigned int>(obj.value("height").toInt());
 }
 
 void TileDataContainer::stringArrayFromJson(std::vector<std::string>& data, const QJsonValue& value)
 {
-	for (const QJsonValue& tag : value.toArray())
-	{
-		data.push_back(tag.toString().toStdString());
-	}
+  for (const QJsonValue& tag : value.toArray())
+  {
+    data.push_back(tag.toString().toStdString());
+  }
 }
 
 
 void TileDataContainer::zonesFromJson(std::vector<Zones>& data, const QJsonValue& value)
 {
-	for (const QJsonValue& zone : value.toArray())
-	{
-		data.push_back( Zones::_from_string_nocase(zone.toString().toStdString().c_str()));
-	}
+  for (const QJsonValue& zone : value.toArray())
+  {
+    data.push_back(Zones::_from_string_nocase(zone.toString().toStdString().c_str()));
+  }
 }
 
-void TileDataContainer::stylesFromJson(TileData &data, const QJsonValue& value)
+void TileDataContainer::stylesFromJson(TileData& data, const QJsonValue& value)
 {
-	// if no values are supplied, we add all styles
-	if (value.toArray().empty() && data.tileType == +TileType::RCI)
-	{
-		for (Style style : Style::_values())
-		{
-			data.style.push_back(style);
-		}
-	}
-	else
-	{
-		for (const QJsonValue& style : value.toArray())
-		{
-			data.style.push_back(Style::_from_string_nocase(style.toString().toStdString().c_str()));
-		}
-	}
+  // if no values are supplied, we add all styles
+  if (value.toArray().empty() && data.tileType == +TileType::RCI)
+  {
+    for (Style style : Style::_values())
+    {
+      data.style.push_back(style);
+    }
+  }
+  else
+  {
+    for (const QJsonValue& style : value.toArray())
+    {
+      data.style.push_back(Style::_from_string_nocase(style.toString().toStdString().c_str()));
+    }
+  }
 }
 
 void TileDataContainer::wealthFromJson(TileData& data, const QJsonValue& value)
 {
-	if (value.toArray().empty() && data.tileType == +TileType::RCI)
-	{
-		for (Wealth wealth : Wealth::_values())
-		{
-			data.wealth.push_back(wealth);
-		}
-	}
-	else
-	{
-		for (const QJsonValue& wealth : value.toArray())
-		{
-			data.wealth.push_back(Wealth::_from_string_nocase(wealth.toString().toStdString().c_str()));
-		}
-	}
+  if (value.toArray().empty() && data.tileType == +TileType::RCI)
+  {
+    for (Wealth wealth : Wealth::_values())
+    {
+      data.wealth.push_back(wealth);
+    }
+  }
+  else
+  {
+    for (const QJsonValue& wealth : value.toArray())
+    {
+      data.wealth.push_back(Wealth::_from_string_nocase(wealth.toString().toStdString().c_str()));
+    }
+  }
 }
 
 void TileDataContainer::tileTypeFromJson(TileType& tileType, const QJsonValue& value)
 {
-	if (!value.toString().isEmpty())
-	{
-		tileType = TileType::_from_string_nocase(value.toString().toStdString().c_str());
-	}
-	else
-	{
-		tileType = TileType::DEFAULT;
-	}
+  if (!value.toString().isEmpty())
+  {
+    tileType = TileType::_from_string_nocase(value.toString().toStdString().c_str());
+  }
+  else
+  {
+    tileType = TileType::DEFAULT;
+  }
 }
 
 //--------------------------------------------------------------------------------
 
 bool TileDataContainer::saveFile()
 {
-	QJsonDocument doc;
-	QJsonArray array;
+  QJsonDocument doc;
+  QJsonArray array;
 
-	for (const TileData& tile : tileData)
-	{
-		QJsonObject obj;
-		obj.insert("id", QString::fromStdString(tile.id));
-		obj.insert("category", QString::fromStdString(tile.category));
-		obj.insert("subCategory", QString::fromStdString(tile.subCategory));
-		obj.insert("title", QString::fromStdString(tile.title));
-		obj.insert("description", QString::fromStdString(tile.description));
-		obj.insert("author", QString::fromStdString(tile.author));
-		obj.insert("price", tile.price);
-		obj.insert("upkeep cost", tile.upkeepCost);
-		obj.insert("power", tile.power);
-		obj.insert("water", tile.water);
-		obj.insert("inhabitants", tile.inhabitants);
-		obj.insert("pollutionLevel", tile.pollutionLevel);
-		obj.insert("happiness", tile.happiness);
-		obj.insert("fireHazardLevel", tile.fireHazardLevel);
-		obj.insert("educationLevel", tile.educationLevel);
-		obj.insert("crimeLevel", tile.crimeLevel);
-		obj.insert("isOverPlacable", tile.isOverPlacable);
-		obj.insert("placeOnGround", tile.placeOnGround);
-		obj.insert("placeOnWater", tile.placeOnWater);
+  for (const TileData& tile : tileData)
+  {
+    QJsonObject obj;
+    obj.insert("id", QString::fromStdString(tile.id));
+    obj.insert("category", QString::fromStdString(tile.category));
+    obj.insert("subCategory", QString::fromStdString(tile.subCategory));
+    obj.insert("title", QString::fromStdString(tile.title));
+    obj.insert("description", QString::fromStdString(tile.description));
+    obj.insert("author", QString::fromStdString(tile.author));
+    obj.insert("price", tile.price);
+    obj.insert("upkeep cost", tile.upkeepCost);
+    obj.insert("power", tile.power);
+    obj.insert("water", tile.water);
+    obj.insert("inhabitants", tile.inhabitants);
+    obj.insert("pollutionLevel", tile.pollutionLevel);
+    obj.insert("happiness", tile.happiness);
+    obj.insert("fireHazardLevel", tile.fireHazardLevel);
+    obj.insert("educationLevel", tile.educationLevel);
+    obj.insert("crimeLevel", tile.crimeLevel);
+    obj.insert("isOverPlacable", tile.isOverPlacable);
+    obj.insert("placeOnGround", tile.placeOnGround);
+    obj.insert("placeOnWater", tile.placeOnWater);
 
-		obj.insert("RequiredTiles", requiredTilesToJson(tile.RequiredTiles));
+    obj.insert("RequiredTiles", requiredTilesToJson(tile.RequiredTiles));
 
-		if (!tile.groundDecoration.empty()) { obj.insert("groundDecoration", stringArrayToJson(tile.groundDecoration)); }
-		if (!tile.tags.empty()) { obj.insert("tags", stringArrayToJson(tile.tags)); }
-		if (!tile.biomes.empty()) { obj.insert("biomes", stringArrayToJson(tile.biomes)); }
-		if (!tile.style.empty()) { obj.insert("style", stylesToJson(tile.style)); }
-		if (!tile.wealth.empty()) { obj.insert("wealth", wealthToJson(tile.wealth)); }
-		if (!tile.zones.empty()) { obj.insert("zones", zonesToJson(tile.zones)); }
+    if (!tile.groundDecoration.empty()) { obj.insert("groundDecoration", stringArrayToJson(tile.groundDecoration)); }
+    if (!tile.tags.empty()) { obj.insert("tags", stringArrayToJson(tile.tags)); }
+    if (!tile.biomes.empty()) { obj.insert("biomes", stringArrayToJson(tile.biomes)); }
+    if (!tile.style.empty()) { obj.insert("style", stylesToJson(tile.style)); }
+    if (!tile.wealth.empty()) { obj.insert("wealth", wealthToJson(tile.wealth)); }
+    if (!tile.zones.empty()) { obj.insert("zones", zonesToJson(tile.zones)); }
 
-		obj.insert("tileType", QString::fromUtf8(tile.tileType._to_string()));
+    obj.insert("tileType", QString::fromUtf8(tile.tileType._to_string()));
 
-		if (!tile.tiles.fileName.empty())
-			obj.insert("tiles", tileSetDataToJson(tile.tiles));
+    if (!tile.tiles.fileName.empty())
+      obj.insert("tiles", tileSetDataToJson(tile.tiles));
 
-		if (!tile.shoreTiles.fileName.empty())
-			obj.insert("shoreLine", tileSetDataToJson(tile.shoreTiles));
+    if (!tile.shoreTiles.fileName.empty())
+      obj.insert("shoreLine", tileSetDataToJson(tile.shoreTiles));
 
-		if (!tile.slopeTiles.fileName.empty())
-			obj.insert("slopeTiles", tileSetDataToJson(tile.slopeTiles));
+    if (!tile.slopeTiles.fileName.empty())
+      obj.insert("slopeTiles", tileSetDataToJson(tile.slopeTiles));
 
-		array.append(obj);
-	}
+    array.append(obj);
+  }
 
-	doc.setArray(array);
+  doc.setArray(array);
 
-	QFile file(fileName);
-	if (!file.open(QIODevice::WriteOnly))
-	{
-		// error handling
-		return false;
-	}
-	file.write(doc.toJson());
-	return true;
+  QFile file(fileName);
+  if (!file.open(QIODevice::WriteOnly))
+  {
+    // error handling
+    return false;
+  }
+  file.write(doc.toJson());
+  return true;
 }
 
 //--------------------------------------------------------------------------------
 
 QJsonObject TileDataContainer::tileSetDataToJson(const TileSetData& data)
 {
-	QJsonObject obj;
+  QJsonObject obj;
 
-	obj.insert("fileName", QString::fromStdString(data.fileName));
-	obj.insert("count", data.count);
-	obj.insert("clip_width", data.clippingWidth);
-	obj.insert("clip_height", data.clippingHeight);
-	obj.insert("offset", data.offset);
-	obj.insert("pickRandomTile", data.pickRandomTile);
+  obj.insert("fileName", QString::fromStdString(data.fileName));
+  obj.insert("count", data.count);
+  obj.insert("clip_width", data.clippingWidth);
+  obj.insert("clip_height", data.clippingHeight);
+  obj.insert("offset", data.offset);
+  obj.insert("pickRandomTile", data.pickRandomTile);
 
-	return obj;
+  return obj;
 }
 
 QJsonObject TileDataContainer::requiredTilesToJson(const RequiredTilesData& data)
 {
-	QJsonObject obj;
-	obj.insert("width", static_cast<int>(data.width));
-	obj.insert("height", static_cast<int>(data.height));
+  QJsonObject obj;
+  obj.insert("width", static_cast<int>(data.width));
+  obj.insert("height", static_cast<int>(data.height));
 
-	return obj;
+  return obj;
 }
 
 QJsonArray TileDataContainer::stringArrayToJson(const std::vector<std::string>& data)
 {
-	QJsonArray result;
+  QJsonArray result;
 
-	for (const std::string value : data)
-	{
-		result.append(QString::fromStdString(value));
-	}
+  for (const std::string value : data)
+  {
+    result.append(QString::fromStdString(value));
+  }
 
-	return result;
+  return result;
 }
 
 QJsonArray TileDataContainer::zonesToJson(const std::vector<Zones>& data)
 {
-	QJsonArray result;
+  QJsonArray result;
 
-	for (const Zones zone : data)
-	{
-		result.append(QString::fromUtf8(zone._to_string()));
-	}
+  for (const Zones zone : data)
+  {
+    result.append(QString::fromUtf8(zone._to_string()));
+  }
 
-	return result;
+  return result;
 }
 
 QJsonArray TileDataContainer::stylesToJson(const std::vector<Style>& data)
 {
-	QJsonArray result;
+  QJsonArray result;
 
-	for (const Style style : data)
-	{
-		result.append(QString::fromUtf8(style._to_string()));
-	}
+  for (const Style style : data)
+  {
+    result.append(QString::fromUtf8(style._to_string()));
+  }
 
-	return result;
+  return result;
 }
 
 QJsonArray TileDataContainer::wealthToJson(const std::vector<Wealth>& data)
 {
-	QJsonArray result;
+  QJsonArray result;
 
-	for (const Wealth wealth : data)
-	{
-		result.append(QString::fromUtf8(wealth._to_string()));
-	}
+  for (const Wealth wealth : data)
+  {
+    result.append(QString::fromUtf8(wealth._to_string()));
+  }
 
-	return result;
+  return result;
 }
 
 

--- a/src/TileDataContainer.cxx
+++ b/src/TileDataContainer.cxx
@@ -34,8 +34,34 @@ std::vector<QString> TileDataContainer::getAllGroundDecorationIDs()
    
   return foundIDs;
 }
+
 //--------------------------------------------------------------------------------
 
+QString TileDataContainer::getBiomeDataFromFile(const QString& fileName)
+{
+  QFile file(fileName);
+  if (!file.exists())
+    return QString();
+
+  if (!file.open(QIODevice::ReadOnly))
+    return file.errorString();
+
+
+  QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+  if (doc.isNull() )
+    return tr("Illegal file content");
+
+  if (!doc.isObject())
+    return tr("Illegal file content");
+
+  QJsonObject obj = doc.object();
+
+  for (const QString& key : obj.keys())
+  {
+    biomes.push_back(key);
+  }
+  return "Loaded File biomeData";
+}
 
 QString TileDataContainer::loadFile(const QString& theFileName)
 {

--- a/src/TileDataContainer.cxx
+++ b/src/TileDataContainer.cxx
@@ -20,6 +20,23 @@ TileData TileDataContainer::getTileData(const QString& id) const
 
 //--------------------------------------------------------------------------------
 
+std::vector<QString> TileDataContainer::getAllGroundDecorationIDs()
+{
+  std::vector<QString> foundIDs;
+
+  for (const TileData& it : tileData)
+  {
+    if (it.tileType == +TileType::GROUNDDECORATION)
+    {
+      foundIDs.push_back(QString::fromStdString( it.id));
+    }
+  }
+   
+  return foundIDs;
+}
+//--------------------------------------------------------------------------------
+
+
 QString TileDataContainer::loadFile(const QString& theFileName)
 {
   fileName = theFileName;

--- a/src/TileDataContainer.hxx
+++ b/src/TileDataContainer.hxx
@@ -12,12 +12,14 @@ class TileDataContainer : public QObject
 {
 public:
   QString loadFile(const QString& fileName);
+  QString getBiomeDataFromFile(const QString& fileName);
   bool saveFile();
 
   bool hasTileData(const QString& id) const;
   TileData getTileData(const QString& id) const;
 
   std::vector<QString> getAllGroundDecorationIDs();
+  std::vector<QString> getBiomes() { return biomes; };
 
   void removeTileData(const QString& id);
   void addTileData(const TileData& tile);
@@ -46,6 +48,7 @@ private:
 private:
   QString fileName;
   QMap<QString, TileData> tileData;
+  std::vector<QString> biomes;
 };
 
 #endif

--- a/src/TileDataContainer.hxx
+++ b/src/TileDataContainer.hxx
@@ -11,26 +11,26 @@
 class TileDataContainer : public QObject
 {
 public:
-  QString loadFile(const QString &fileName);
+  QString loadFile(const QString& fileName);
   bool saveFile();
 
-  bool hasTileData(const QString &id) const;
-  TileData getTileData(const QString &id) const;
+  bool hasTileData(const QString& id) const;
+  TileData getTileData(const QString& id) const;
 
-  void removeTileData(const QString &id);
-  void addTileData(const TileData &tile);
+  void removeTileData(const QString& id);
+  void addTileData(const TileData& tile);
 
   using Map = QMap<QString, TileData>;
   Map::iterator begin() { return tileData.begin(); }
   Map::iterator end() { return tileData.end(); }
 
 private:
-  void stringArrayFromJson(std::vector<std::string> &data, const QJsonValue& value);
+  void stringArrayFromJson(std::vector<std::string>& data, const QJsonValue& value);
   void biomesFromJson(TileData& data, const QJsonValue& value);
   void groundDecorationFromJson(TileData& data, const QJsonValue& value);
-  void tileSetDataFromJson(TileSetData &data, const QJsonValue &value);
+  void tileSetDataFromJson(TileSetData& data, const QJsonValue& value);
   void requiredTilesFromJson(RequiredTilesData& data, const QJsonValue& value);
-  void zonesFromJson(std::vector<Zones> &data, const QJsonValue& value);
+  void zonesFromJson(std::vector<Zones>& data, const QJsonValue& value);
   void stylesFromJson(TileData& data, const QJsonValue& value);
   void wealthFromJson(TileData& data, const QJsonValue& value);
   void tileTypeFromJson(TileType& tileType, const QJsonValue& value);

--- a/src/TileDataContainer.hxx
+++ b/src/TileDataContainer.hxx
@@ -17,6 +17,8 @@ public:
   bool hasTileData(const QString& id) const;
   TileData getTileData(const QString& id) const;
 
+  std::vector<QString> getAllGroundDecorationIDs();
+
   void removeTileData(const QString& id);
   void addTileData(const TileData& tile);
 

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -169,25 +169,50 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
 
     TileData tile = tileContainer.getTileData(parentUI.id->text());
     itemSelectionDialog.availableItems->clear();
+    itemSelectionDialog.usedItems->clear();
 
     for (const auto biome : tile.biomes)
     {
       itemSelectionDialog.availableItems->addItem(QString::fromStdString(biome));
     }
     groundDecorationSelector->setWindowTitle("Select Biome");
+    itemSelectionDialog.listOfLabel->setText("Available Biomes");
+    itemSelectionDialog.usedLabel->setText("Used Biomes");
     biomeSelector->show();
 
     });
 
   connect(parentUI.groundDecorationButton, QOverload<bool>::of(&QPushButton::clicked), this, [parentUI, itemSelectionDialog, this]() {
-    itemSelectionDialog.availableItems->clear();
-    //TileData tile = tileContainer.getTileData(parentUI.id->text());
 
-    for (const QString biome : tileContainer.getAllGroundDecorationIDs())
+    itemSelectionDialog.availableItems->clear();
+    itemSelectionDialog.usedItems->clear();
+    TileData tile = tileContainer.getTileData(parentUI.id->text());
+
+
+    for (const QString& groundDecoration : tileContainer.getAllGroundDecorationIDs())
     {
-      itemSelectionDialog.availableItems->addItem(biome);
+      itemSelectionDialog.availableItems->addItem(groundDecoration);
     }
+
+    std::vector<std::string>groundDecorationUsed;
+    commaSeperatedStringToVector(parentUI.groundDecoration->text().toStdString(), groundDecorationUsed);
+
+    for (const auto& usedDecoration : groundDecorationUsed)
+    {
+      itemSelectionDialog.usedItems->addItem(QString::fromStdString(usedDecoration));
+
+      for (int a = 0; a < itemSelectionDialog.availableItems->count() + 1; a++)
+      {
+        if (itemSelectionDialog.availableItems->item(a) && itemSelectionDialog.availableItems->item(a)->text() == QString::fromStdString(usedDecoration))
+        {
+          itemSelectionDialog.availableItems->takeItem(a);
+        }
+      }
+    }
+
     groundDecorationSelector->setWindowTitle("Select GroundDecoration");
+    itemSelectionDialog.listOfLabel->setText("Available GroundDecoration");
+    itemSelectionDialog.usedLabel->setText("Used GroundDecoration");
     groundDecorationSelector->show();
 
     });
@@ -203,15 +228,23 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
     });
 
   connect(itemSelectionDialog.okButton, QOverload<bool>::of(&QPushButton::clicked), this, [parentUI, itemSelectionDialog, this]() {
-    if (itemSelectionDialog.usedItems->count() == 0)
+    if (itemSelectionDialog.usedItems->count() > 0)
     {
-
+    QString items;
       for (int i = 0; i < itemSelectionDialog.usedItems->count(); i++)
       {
-        qInfo() << itemSelectionDialog.usedItems->item(i)->text();
+        qInfo() << "before " << items;
+        items += itemSelectionDialog.usedItems->item(i)->text();
+        qInfo() << "after  " << items;
+
+        if (itemSelectionDialog.usedItems->count() - i > 1)
+        {
+          items += ",";
+        }
       }
+    parentUI.groundDecoration->setText(items);
     }
-    qInfo() << "clicked OK";
+
     biomeSelector->hide();
     groundDecorationSelector->hide();
     });

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -187,7 +187,7 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
         }
       }
       if (!found)
-      { 
+      {
         itemSelectionDialog.availableItems->addItem(biome);
       }
     }
@@ -208,7 +208,7 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
     std::vector<std::string>groundDecorationUsed;
     commaSeperatedStringToVector(parentUI.groundDecoration->text().toStdString(), groundDecorationUsed);
 
-      for (const QString& groundDecoration : tileContainer.getAllGroundDecorationIDs())
+    for (const QString& groundDecoration : tileContainer.getAllGroundDecorationIDs())
     {
       bool found = false;
       for (const auto& usedDecoration : groundDecorationUsed)
@@ -242,6 +242,22 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
     delete itemSelectionDialog.availableItems->currentItem();
     });
 
+  connect(itemSelectionDialog.clearButton, QOverload<bool>::of(&QPushButton::clicked), this, [parentUI, itemSelectionDialog, this]() {
+    // store count as it will change when we manipulate the list
+    int count = itemSelectionDialog.usedItems->count() - 1;
+    // iterate over all items, starting backwards to avoid index out of range
+    for (int i = count; i >= 0; --i)
+    {
+      // we have to clone the widget, moving is not possible
+      QListWidgetItem* widget = itemSelectionDialog.usedItems->item(i)->clone();
+      if (widget) // better be safe than sorry
+      {
+        itemSelectionDialog.availableItems->addItem(widget); // add the cloned item to the list
+        itemSelectionDialog.usedItems->takeItem(i); // remove the old item we found and cloned
+      }
+    }
+    });
+
   connect(itemSelectionDialog.okButton, QOverload<bool>::of(&QPushButton::clicked), this, [parentUI, itemSelectionDialog, this]() {
     QString items;
     if (itemSelectionDialog.usedItems->count() > 0)
@@ -266,7 +282,7 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
       groundDecorationSelector->hide();
       parentUI.groundDecoration->setText(items);
     }
-    else 
+    else
     {
       qInfo() << "Error! Clicked OK on an unimplemented DIalog!";
     }

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -228,23 +228,20 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
     });
 
   connect(itemSelectionDialog.okButton, QOverload<bool>::of(&QPushButton::clicked), this, [parentUI, itemSelectionDialog, this]() {
+    QString items;
     if (itemSelectionDialog.usedItems->count() > 0)
     {
-    QString items;
       for (int i = 0; i < itemSelectionDialog.usedItems->count(); i++)
       {
-        qInfo() << "before " << items;
         items += itemSelectionDialog.usedItems->item(i)->text();
-        qInfo() << "after  " << items;
-
         if (itemSelectionDialog.usedItems->count() - i > 1)
         {
           items += ",";
         }
       }
-    parentUI.groundDecoration->setText(items);
     }
 
+    parentUI.groundDecoration->setText(items);
     biomeSelector->hide();
     groundDecorationSelector->hide();
     });

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -33,11 +33,13 @@ TileDataUI::TileDataUI()
   ui.setupUi(w);
   splitter->addWidget(w);
 
-  biomeSelector = new QWidget;
+  biomeSelector = new QWidget(this, Qt::Popup | Qt::Dialog);;
+
   itemSelection.setupUi(biomeSelector);
   setupNew(ui, itemSelection);
 
-  groundDecorationSelector = new QWidget;
+  groundDecorationSelector = new QWidget(this, Qt::Popup | Qt::Dialog);;
+
   itemSelection.setupUi(groundDecorationSelector);
   setupNew(ui, itemSelection);
 
@@ -193,6 +195,7 @@ void TileDataUI::setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelec
     itemSelectionDialog.listOfLabel->setText("Available Biomes");
     itemSelectionDialog.usedLabel->setText("Used Biomes");
     biomeSelector->setWindowTitle("Select Biome");
+    biomeSelector->setWindowModality(Qt::WindowModal);
     biomeSelector->show();
 
     });

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -952,8 +952,7 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
   int numCount = ui.count->value();
   int numOffset = ui.offset->value();
   // tiledata preview
-  if (numCount > 1)
-  {
+
     QPixmap pix = *(ui.origImage->pixmap());
     QPainter* paint = new QPainter(&pix);
 
@@ -963,18 +962,21 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
     int offsetY = pix.height() - ui.height->value(); // in case our height is smaller then the total height, start drawing from bottom up
     int offsetX = 0;
 
-    for (int i = 0; i < numCount; i++)
+    if (numCount > 1 || numOffset >= 1)
     {
-      if (numOffset >= 0)
+      for (int i = 0; i < numCount; i++)
       {
-        offsetX = (width * numOffset) + (width * i);
+        if (numOffset >= 0)
+        {
+          offsetX = (width * numOffset) + (width * i);
+        }
+        else
+        {
+          offsetX = (width * i);
+        }
+        paint->drawRect(offsetX, offsetY, width - 1, height);
       }
-      else
-      {
-        offsetX = (width * i);
-      }
-      paint->drawRect(offsetX, offsetY, width - 1, height);
-    }
+  }
     delete paint;
 
     // Scale the image, if necessary
@@ -986,8 +988,8 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
 
     // return the modified image
     return pix;
-  }
-  return *(ui.origImage->pixmap());
+  
+  //return *(ui.origImage->pixmap());
 }
 
 //--------------------------------------------------------------------------------

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -170,7 +170,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
 
       // recalc width based on current count
       int spriteSheetLength = ui.origImage->pixmap()->width();
-      int numOffset = ui.offset->value();
+      int numOffset = abs(ui.offset->value());
       int numCount = ui.count->value();
       int singleTile_width = 0;
 
@@ -261,7 +261,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
     TileType tileType = TileType::_from_index(parentUI.TileTypeComboBox->currentIndex());
 
     int spriteSheetLength = ui.origImage->pixmap()->width();
-    int numOffset = ui.offset->value();
+    int numOffset = abs(ui.offset->value());
     int numCount = ui.count->value();
     int singleTile_width = 0;
 
@@ -287,7 +287,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
     ui.width->setValue(singleTile_width);
 
     // set tileSetPreview selection boxes
-    //ui.image->setPixmap(preparePixMap(ui));
+    ui.image->setPixmap(preparePixMap(ui));
     });
 
   connect(ui.offset, QOverload<int>::of(&QSpinBox::valueChanged), this, [ui, this](int value) {
@@ -295,7 +295,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
       return;
 
     int spriteSheetLength = ui.origImage->pixmap()->width();
-    int numOffset = ui.offset->value();
+    int numOffset = abs(ui.offset->value());
     int numCount = ui.count->value();
     int singleTile_width = 0;
 
@@ -311,7 +311,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
     ui.width->setValue(singleTile_width);
 
     // set tileSetPreview selection boxes
-    //ui.image->setPixmap(preparePixMap(ui));
+    ui.image->setPixmap(preparePixMap(ui));
     });
 
   ui.origImage->hide(); // a hidden storage for the original sized pixmap
@@ -323,7 +323,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
         return;
 
       // set tileSetPreview selection boxes
-      //ui.image->setPixmap(preparePixMap(ui));
+      ui.image->setPixmap(preparePixMap(ui));
 
     });
 }
@@ -790,7 +790,6 @@ void TileDataUI::fillTileSetDataWidget(const Ui_TileSetDataUi& ui, const TileSet
   ui.offset->setValue(data.offset);
   ui.pickRandomTile->setChecked(data.pickRandomTile);
 
-
   ui.image->setPixmap(preparePixMap(ui)); // set tileSetPreview selection boxes
 
   ui.deleteButton->setEnabled(!pix.isNull());
@@ -964,10 +963,17 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
     int offsetY = pix.height() - ui.height->value(); // in case our height is smaller then the total height, start drawing from bottom up
     qInfo() << "width " << width;
     qInfo() << "height " << height;
-
+    int offsetX = 0;
     for (int i = 0; i < numCount; i++)
     {
-      int offsetX = (width * numOffset) + (width * i);
+      if (numOffset >= 0)
+      {
+        offsetX = (width * numOffset) + (width * i);
+      }
+      else
+      {
+        offsetX = (width * i);
+      }
       qInfo() << "Offset " << offsetX;
       paint->drawRect(offsetX, offsetY, width -1, height);
     }

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -943,7 +943,7 @@ void TileDataUI::duplicateItem()
 
 QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
 {
-  if (!ui.origImage->pixmap())
+  if (ui.origImage->pixmap()->isNull())
   {
     QPixmap emptyPixMap;
     return emptyPixMap;

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -955,16 +955,14 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
   if (numCount > 1)
   {
     QPixmap pix = *(ui.origImage->pixmap());
-    qInfo() << "orig width " << pix.width();
-
     QPainter* paint = new QPainter(&pix);
+
     paint->setPen(QColor(255, 34, 255, 255));
     int width = ui.width->value();
     int height = ui.height->value() - 1;
     int offsetY = pix.height() - ui.height->value(); // in case our height is smaller then the total height, start drawing from bottom up
-    qInfo() << "width " << width;
-    qInfo() << "height " << height;
     int offsetX = 0;
+
     for (int i = 0; i < numCount; i++)
     {
       if (numOffset >= 0)
@@ -975,7 +973,6 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
       {
         offsetX = (width * i);
       }
-      qInfo() << "Offset " << offsetX;
       paint->drawRect(offsetX, offsetY, width -1, height);
     }
     delete paint;
@@ -988,8 +985,6 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
 
 
     // return the modified image
-    qInfo() << "orig widthAFTER " << pix.width();
-
     return pix;
   }
   return *(ui.origImage->pixmap());

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -39,7 +39,7 @@ TileDataUI::TileDataUI()
   ui.author->setMaxLength(TD_AUTHOR_MAX_CHARS);
   ui.buildCost->setRange(TD_PRICE_MIN, TD_PRICE_MAX);
   ui.upkeepCost->setRange(TD_UPKEEP_MIN, TD_UPKEEP_MAX);
-  ui.educationLevel ->setRange(TD_EDUCATION_MIN, TD_EDUCATION_MAX);
+  ui.educationLevel->setRange(TD_EDUCATION_MIN, TD_EDUCATION_MAX);
   ui.fireHazardLevel->setRange(TD_FIREDANGER_MIN, TD_FIREDANGER_MAX);
   ui.crimeLevel->setRange(TD_CRIME_MIN, TD_CRIME_MAX);
   ui.pollutionLevel->setRange(TD_POLLUTION_MIN, TD_POLLUTION_MAX);
@@ -253,12 +253,12 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
         dynamic_cast<QPushButton*>(parentUI.stylesButtonsHorizontalLayout->itemAt(i)->widget())->setEnabled(false);
       }
     }
-  });
+    });
 
   connect(ui.count, QOverload<int>::of(&QSpinBox::valueChanged), this, [ui, parentUI, this](int value) {
     if (!ui.origImage->pixmap() || !ui.image->pixmap())
       return;
-    
+
     TileType tileType = TileType::_from_index(parentUI.TileTypeComboBox->currentIndex());
 
     int spriteSheetLength = ui.origImage->pixmap()->width();
@@ -292,7 +292,7 @@ void TileDataUI::setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI)
     });
 
   connect(ui.offset, QOverload<int>::of(&QSpinBox::valueChanged), this, [ui, this](int value) {
-    if (!ui.origImage->pixmap() || !ui.image->pixmap() )
+    if (!ui.origImage->pixmap() || !ui.image->pixmap())
       return;
 
     int spriteSheetLength = ui.origImage->pixmap()->width();
@@ -359,7 +359,7 @@ bool TileDataUI::loadFile(const QString& fileName)
 
     root->addChild(newTreeItem(tile));
   }
-  
+
   tree->resizeColumnToContents(0);
   tree->resize(tree->columnWidth(0), tree->height());
 
@@ -431,7 +431,7 @@ void TileDataUI::itemSelected(QTreeWidgetItem* current, QTreeWidgetItem* previou
     }
   }
 
-  
+
 
   if (!current || !current->data(0, Qt::UserRole).isValid())
     return;
@@ -973,7 +973,7 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
       {
         offsetX = (width * i);
       }
-      paint->drawRect(offsetX, offsetY, width -1, height);
+      paint->drawRect(offsetX, offsetY, width - 1, height);
     }
     delete paint;
 

--- a/src/TileDataUI.cxx
+++ b/src/TileDataUI.cxx
@@ -113,6 +113,7 @@ void TileDataUI::createActions()
   action->setIcon(QIcon::fromTheme("edit-delete"));
   action->setShortcut(QKeySequence::Cut);
   connect(action, &QAction::triggered, this, &TileDataUI::deleteItem);
+
   toolBar->addAction(action);
   editMenu->addAction(action);
 
@@ -995,3 +996,11 @@ QPixmap TileDataUI::preparePixMap(const Ui_TileSetDataUi& ui)
 }
 
 //--------------------------------------------------------------------------------
+
+void TileDataUI::keyPressEvent(QKeyEvent* event)
+{
+  if (event->key() == Qt::Key_Delete)
+  {
+    deleteItem();
+  }
+}

--- a/src/TileDataUI.hxx
+++ b/src/TileDataUI.hxx
@@ -42,6 +42,7 @@ private: // methods
   void toggleActiveZoneButtons(const std::vector<Zones>& data); /// when an item is loaded, check all zones button that are assigned in the json
   void toggleActiveStyleButtons(const std::vector<Style>& data); /// when an item is loaded, check all style button that are assigned in the json
   void toggleActiveWealthButtons(const std::vector<Wealth>& data); /// when an item is loaded, check all wealth button that are assigned in the json
+  QPixmap preparePixMap(const Ui_TileSetDataUi& ui);
 
   QTreeWidgetItem *newTreeRootItem(const TileData &tile);
   QTreeWidgetItem *newTreeItem(const TileData &tile);

--- a/src/TileDataUI.hxx
+++ b/src/TileDataUI.hxx
@@ -67,6 +67,9 @@ private: // members
   Ui_TileSetDataUi shoreTileSet;
   Ui_TileSetDataUi slopeSet;
   Ui_TileDataUi ui;
+
+protected:
+  virtual void keyPressEvent(QKeyEvent*);
 };
 
 #endif

--- a/src/TileDataUI.hxx
+++ b/src/TileDataUI.hxx
@@ -20,20 +20,20 @@ class TileDataUI : public QMainWindow
 public:
   TileDataUI();
 
-  bool loadFile(const QString &name);
+  bool loadFile(const QString& name);
 
 protected:
-  void closeEvent(QCloseEvent *event) override;
+  void closeEvent(QCloseEvent* event) override;
 
 private slots:
-  void itemSelected(QTreeWidgetItem *current, QTreeWidgetItem *previous);
+  void itemSelected(QTreeWidgetItem* current, QTreeWidgetItem* previous);
   void saveTileData();
   void newItem();
   void deleteItem();
   void duplicateItem();
 
 private: // methods
-  void setup(Ui_TileSetDataUi &ui, Ui_TileDataUi &parentUI);
+  void setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI);
   void createActions();
   void createZoneButtons(); /// dynamically create Buttons for assignable zones from the Zones enum
   void createStyleButtons(); /// dynamically create Buttons for assignable styles from the Style enum
@@ -44,25 +44,25 @@ private: // methods
   void toggleActiveWealthButtons(const std::vector<Wealth>& data); /// when an item is loaded, check all wealth button that are assigned in the json
   QPixmap preparePixMap(const Ui_TileSetDataUi& ui);
 
-  QTreeWidgetItem *newTreeRootItem(const TileData &tile);
-  QTreeWidgetItem *newTreeItem(const TileData &tile);
-  void addItem(const TileData &tile);
-  void ensureUniqueId(TileData &tile);
-  void writeToTileData(TileData &tile);
+  QTreeWidgetItem* newTreeRootItem(const TileData& tile);
+  QTreeWidgetItem* newTreeItem(const TileData& tile);
+  void addItem(const TileData& tile);
+  void ensureUniqueId(TileData& tile);
+  void writeToTileData(TileData& tile);
   void readFromTileData(const TileData& tile);
   std::vector<Zones> ZonesEnumVectorFromString(QString zones);
   std::vector<Zones> ZonesEnumVectorFromButtons();
   std::vector<Style> StyleEnumVectorFromButtons();
   std::vector<Wealth> WealthEnumVectorFromButtons();
   std::string ZonesEnumVectorToString(const std::vector<Zones>& data);
-  void fillTileSetDataWidget(const Ui_TileSetDataUi &ui, const TileSetData &data);
-  void readTileSetDataWidget(const Ui_TileSetDataUi &ui, TileSetData &data);
-  QJsonObject tileSetDataToJson(const TileSetData &data);
-      
+  void fillTileSetDataWidget(const Ui_TileSetDataUi& ui, const TileSetData& data);
+  void readTileSetDataWidget(const Ui_TileSetDataUi& ui, TileSetData& data);
+  QJsonObject tileSetDataToJson(const TileSetData& data);
+
 private: // members
   TileDataContainer tileContainer;
-  QTreeWidget *tree;
-  QSplitter *splitter;
+  QTreeWidget* tree;
+  QSplitter* splitter;
   Ui_TileSetDataUi tilesSet;
   Ui_TileSetDataUi shoreTileSet;
   Ui_TileSetDataUi slopeSet;

--- a/src/TileDataUI.hxx
+++ b/src/TileDataUI.hxx
@@ -8,6 +8,8 @@
 
 #include "ui_TileDataUI.h"
 #include "ui_TileSetDataUI.h"
+#include "ui_ItemSelectionUI.h"
+
 #include "helpers.hxx"
 
 #include "TileDataContainer.hxx"
@@ -33,7 +35,8 @@ private slots:
   void duplicateItem();
 
 private: // methods
-  void setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI);
+  void setup(Ui_TileSetDataUi& ui, Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelectionDialog);
+  void setupNew(Ui_TileDataUi& parentUI, Ui_ItemSelectionUI& itemSelectionDialog);
   void createActions();
   void createZoneButtons(); /// dynamically create Buttons for assignable zones from the Zones enum
   void createStyleButtons(); /// dynamically create Buttons for assignable styles from the Style enum
@@ -63,10 +66,14 @@ private: // members
   TileDataContainer tileContainer;
   QTreeWidget* tree;
   QSplitter* splitter;
+  QWidget* biomeSelector;
+  QWidget* groundDecorationSelector;
   Ui_TileSetDataUi tilesSet;
   Ui_TileSetDataUi shoreTileSet;
   Ui_TileSetDataUi slopeSet;
   Ui_TileDataUi ui;
+  Ui_ItemSelectionUI itemSelection;
+  
 
 protected:
   virtual void keyPressEvent(QKeyEvent*);

--- a/src/TileDataUI.hxx
+++ b/src/TileDataUI.hxx
@@ -23,6 +23,7 @@ public:
   TileDataUI();
 
   bool loadFile(const QString& name);
+  bool loadBiomeData(const QString& name);
 
 protected:
   void closeEvent(QCloseEvent* event) override;

--- a/src/TileDataUI.ui
+++ b/src/TileDataUI.ui
@@ -8,7 +8,7 @@
     <x>0</x>
     <y>0</y>
     <width>1033</width>
-    <height>850</height>
+    <height>851</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -104,27 +104,79 @@
    </item>
    <item>
     <layout class="QGridLayout" name="TilePropertiesGridLayout">
-     <item row="9" column="4">
-      <widget class="QLabel" name="label_7">
-       <property name="toolTip">
-        <string>Water production of this item. Negative values means power consumption.</string>
-       </property>
+     <item row="12" column="3">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="BiomeButton">
+         <property name="text">
+          <string>Edit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="biomes">
+         <property name="toolTip">
+          <string>Restrict this building to spawn only in the given biomes. Must correspond to a biome defined in resources/data/TerrainGen.json. Values must be commaseperated</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Water production</string>
+        <string>Title</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_18">
+     <item row="3" column="5">
+      <widget class="QLabel" name="label_21">
        <property name="toolTip">
-        <string>Restrict this building to a zone type</string>
+        <string>How much education this building provides (educational building) / requires (job)</string>
        </property>
        <property name="text">
-        <string>Zones</string>
+        <string>Education</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="4">
+     <item row="4" column="3">
+      <layout class="QHBoxLayout" name="zoneButtonsHorizontalLayout"/>
+     </item>
+     <item row="10" column="3">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="placeOnGround">
+         <property name="toolTip">
+          <string>Whether or not this building be placed on ground.	</string>
+         </property>
+         <property name="text">
+          <string>placeOnGround</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="placeOnWater">
+         <property name="toolTip">
+          <string>Whether or not this building be placed on water.	</string>
+         </property>
+         <property name="text">
+          <string>placeOnWater</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="isOverPlacable">
+         <property name="toolTip">
+          <string>Determines if other tiles can be placed over this one tile or if it needs to be demolished first</string>
+         </property>
+         <property name="text">
+          <string>isOverPlacable</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="13" column="5">
       <widget class="QLabel" name="label_23">
        <property name="toolTip">
         <string>Pollution rate this building produces or prevents (police station)</string>
@@ -134,10 +186,80 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
-      <widget class="QComboBox" name="TileTypeComboBox">
+     <item row="4" column="5">
+      <widget class="QLabel" name="label_24">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tiletype determines the tiles behaviour.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;DEFAULT&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Default is for buildings and practically everything that'll be placed on the TERRAIN layer&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;TERRAIN&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Terrain itself&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;WATER&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Water terrain&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;BLUEPRIN&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#000000;&quot;&gt;T&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Same as terrain, but gets placed on the BLUEPRINT layer&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;AUTOTILE&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#24292e;&quot;/&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt;- Autotiling to itself, like roads, power lines, etc&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;ZONE&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Zones (rectangular placement)&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;GROUNDDECORATION&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Draw this Tile on GROUNDDECORATION layer. Buildings can be placed over it&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;UNDERGROUND&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#24292e;&quot;/&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt;- same as AUTOTILE, but for the BLUEPRINT layer&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>Fire hazard rate this building produces or prevents (police station)</string>
+       </property>
+       <property name="text">
+        <string>FireHazard</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="QLabel" name="label_5">
+       <property name="toolTip">
+        <string>Author of this item</string>
+       </property>
+       <property name="text">
+        <string>Author</string>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="5">
+      <widget class="QLabel" name="label_17">
+       <property name="toolTip">
+        <string>The effect on happiness around this building.	</string>
+       </property>
+       <property name="text">
+        <string>Happiness</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="QLineEdit" name="author">
+       <property name="toolTip">
+        <string>Author of this item</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <layout class="QHBoxLayout" name="wealthButtonsHorizontalLayout"/>
+     </item>
+     <item row="10" column="5">
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Upkeep cost</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="QLabel" name="label_14">
+       <property name="toolTip">
+        <string>How many residents / workers this building can hold. Also how much jobs it provides</string>
+       </property>
+       <property name="text">
+        <string>Inhabitants</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="5">
+      <widget class="QLabel" name="label_22">
+       <property name="toolTip">
+        <string>Crime rate this building produces or prevents (police station)</string>
+       </property>
+       <property name="text">
+        <string>Crime</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_15">
+       <property name="toolTip">
+        <string>Multiple tags for searching this item ingame. Seperate tags with a comma.</string>
+       </property>
+       <property name="text">
+        <string>Tags</string>
        </property>
       </widget>
      </item>
@@ -151,17 +273,14 @@
        </property>
       </widget>
      </item>
-     <item row="14" column="4">
-      <widget class="QLabel" name="label_17">
+     <item row="9" column="6">
+      <widget class="QSpinBox" name="waterProduction">
        <property name="toolTip">
-        <string>The effect on happiness around this building.	</string>
-       </property>
-       <property name="text">
-        <string>Happiness</string>
+        <string>Water production of this item. Negative values means power consumption.</string>
        </property>
       </widget>
      </item>
-     <item row="13" column="5">
+     <item row="13" column="6">
       <widget class="QSpinBox" name="pollutionLevel">
        <property name="toolTip">
         <string>Pollution rate this building produces or prevents (police station)</string>
@@ -175,133 +294,65 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="4">
-      <widget class="QLabel" name="label_9">
-       <property name="text">
-        <string>Build cost</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="4">
-      <widget class="QLabel" name="label_22">
+     <item row="15" column="5">
+      <widget class="QLabel" name="label_11">
        <property name="toolTip">
-        <string>Crime rate this building produces or prevents (police station)</string>
+        <string>How many tiles this building uses.</string>
        </property>
        <property name="text">
-        <string>Crime</string>
+        <string>RequiredTiles</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="4">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Upkeep cost</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="5">
-      <widget class="QSpinBox" name="upkeepCost">
+     <item row="13" column="0">
+      <widget class="QLabel" name="label_13">
        <property name="toolTip">
-        <string>Monthly upkeep cost</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family:'-apple-system','BlinkMacSystemFont','Segoe UI','Helvetica','Arial','sans-serif','Apple Color Emoji','Segoe UI Emoji'; font-size:16px; color:#24292e; background-color:#ffffff;&quot;&gt;tileID of the item that should be drawn on ground below sprite instead of terrain (grass, concrete, ...). When more than one tileID is supplied, a random ground decoration is chosen from the list on placement. Must be a tileID with tileType GroundDecoration.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'-apple-system','BlinkMacSystemFont','Segoe UI','Helvetica','Arial','sans-serif','Apple Color Emoji','Segoe UI Emoji'; font-size:16px; color:#24292e; background-color:#ffffff;&quot;&gt;Valuesmust be commaseperated.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>GroundDecoration</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="5">
+     <item row="11" column="6">
       <widget class="QSpinBox" name="buildCost">
        <property name="toolTip">
         <string>Buildcost</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_20">
-       <property name="toolTip">
-        <string>Restrict this building to a certain wealth level. </string>
-       </property>
-       <property name="text">
-        <string>Wealth</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="4">
-      <widget class="QLabel" name="label_14">
-       <property name="toolTip">
-        <string>How many residents / workers this building can hold. Also how much jobs it provides</string>
-       </property>
-       <property name="text">
-        <string>Inhabitants</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <widget class="QLabel" name="label_5">
-       <property name="toolTip">
-        <string>Author of this item</string>
-       </property>
-       <property name="text">
-        <string>Author</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QPlainTextEdit" name="description">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>10</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Description of the item that is shown in it's details</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="5">
-      <widget class="QSpinBox" name="waterProduction">
-       <property name="toolTip">
-        <string>Water production of this item. Negative values means power consumption.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="5">
+     <item row="5" column="6">
       <widget class="QSpinBox" name="powerProduction">
        <property name="toolTip">
         <string>Power production of this item. Negative values means power consumption.</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
+     <item row="3" column="6">
+      <widget class="QSpinBox" name="educationLevel">
+       <property name="toolTip">
+        <string>How much education this building provides (educational building) / requires (job)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="5">
+      <widget class="QLabel" name="label_9">
        <property name="text">
-        <string>Title</string>
+        <string>Build cost</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="5">
-      <widget class="QLineEdit" name="author">
+     <item row="12" column="0">
+      <widget class="QLabel" name="label_16">
        <property name="toolTip">
-        <string>Author of this item</string>
+        <string>Restrict this building to spawn only in the given biomes. Must correspond to a biome defined in resources/data/TerrainGen.json. Values must be commaseperated</string>
+       </property>
+       <property name="text">
+        <string>Biomes</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="2">
-      <layout class="QHBoxLayout" name="zoneButtonsHorizontalLayout"/>
-     </item>
-     <item row="12" column="5">
-      <widget class="QSpinBox" name="crimeLevel">
-       <property name="toolTip">
-        <string>Crime rate this building produces or prevents (police station)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="5">
-      <widget class="QSpinBox" name="happiness">
-       <property name="toolTip">
-        <string>The effect on happiness around this building.	</string>
-       </property>
-      </widget>
-     </item>
-     <item row="15" column="5">
+     <item row="15" column="6">
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
         <widget class="QSpinBox" name="requiredTilesWidth">
@@ -364,58 +415,73 @@
        </item>
       </layout>
      </item>
-     <item row="4" column="5">
-      <widget class="QSpinBox" name="fireHazardLevel">
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_18">
        <property name="toolTip">
-        <string>Fire hazard rate this building produces or prevents (police station)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="5">
-      <widget class="QSpinBox" name="educationLevel">
-       <property name="toolTip">
-        <string>How much education this building provides (educational building) / requires (job)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="5">
-      <widget class="QSpinBox" name="inhabitants">
-       <property name="toolTip">
-        <string>How many residents / workers this building can hold. Also how much jobs it provides</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="4">
-      <widget class="QLabel" name="label_6">
-       <property name="toolTip">
-        <string>Power production of this item. Negative values means power consumption.</string>
+        <string>Restrict this building to a zone type</string>
        </property>
        <property name="text">
-        <string>Power production</string>
+        <string>Zones</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
-      <widget class="QLabel" name="label_21">
+     <item row="3" column="3">
+      <widget class="QComboBox" name="TileTypeComboBox">
        <property name="toolTip">
-        <string>How much education this building provides (educational building) / requires (job)</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The tiletype determines the tiles behaviour.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;DEFAULT&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Default is for buildings and practically everything that'll be placed on the TERRAIN layer&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;TERRAIN&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Terrain itself&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;WATER&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Water terrain&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;BLUEPRIN&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#000000;&quot;&gt;T&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Same as terrain, but gets placed on the BLUEPRINT layer&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;AUTOTILE&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#24292e;&quot;/&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt;- Autotiling to itself, like roads, power lines, etc&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;ZONE&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Zones (rectangular placement)&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;GROUNDDECORATION&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt; - Draw this Tile on GROUNDDECORATION layer. Buildings can be placed over it&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; font-weight:600; color:#24292e;&quot;&gt;UNDERGROUND&lt;/span&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#24292e;&quot;/&gt;&lt;span style=&quot; font-family:'SFMono-Regular','Consolas','Liberation Mono','Menlo','monospace'; color:#000000;&quot;&gt;- same as AUTOTILE, but for the BLUEPRINT layer&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_19">
+       <property name="toolTip">
+        <string>Restrict this building to certain Art Styles. </string>
        </property>
        <property name="text">
-        <string>Education</string>
+        <string>Styles</string>
        </property>
       </widget>
      </item>
-     <item row="15" column="4">
-      <widget class="QLabel" name="label_11">
+     <item row="2" column="3">
+      <widget class="QPlainTextEdit" name="description">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>50</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>50</height>
+        </size>
+       </property>
        <property name="toolTip">
-        <string>How many tiles this building uses.</string>
-       </property>
-       <property name="text">
-        <string>RequiredTiles</string>
+        <string>Description of the item that is shown in it's details</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="10" column="6">
+      <widget class="QSpinBox" name="upkeepCost">
+       <property name="toolTip">
+        <string>Monthly upkeep cost</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="6">
+      <widget class="QSpinBox" name="crimeLevel">
+       <property name="toolTip">
+        <string>Crime rate this building produces or prevents (police station)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
       <widget class="QLineEdit" name="title">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -434,117 +500,85 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="4">
-      <widget class="QLabel" name="label_24">
+     <item row="2" column="6">
+      <widget class="QSpinBox" name="inhabitants">
        <property name="toolTip">
-        <string>Fire hazard rate this building produces or prevents (police station)</string>
-       </property>
-       <property name="text">
-        <string>FireHazard</string>
+        <string>How many residents / workers this building can hold. Also how much jobs it provides</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="2">
-      <layout class="QHBoxLayout" name="wealthButtonsHorizontalLayout"/>
+     <item row="5" column="5">
+      <widget class="QLabel" name="label_6">
+       <property name="toolTip">
+        <string>Power production of this item. Negative values means power consumption.</string>
+       </property>
+       <property name="text">
+        <string>Power production</string>
+       </property>
+      </widget>
      </item>
-     <item row="10" column="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="placeOnGround">
-         <property name="toolTip">
-          <string>Whether or not this building be placed on ground.	</string>
-         </property>
-         <property name="text">
-          <string>placeOnGround</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="placeOnWater">
-         <property name="toolTip">
-          <string>Whether or not this building be placed on water.	</string>
-         </property>
-         <property name="text">
-          <string>placeOnWater</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="isOverPlacable">
-         <property name="toolTip">
-          <string>Determines if other tiles can be placed over this one tile or if it needs to be demolished first</string>
-         </property>
-         <property name="text">
-          <string>isOverPlacable</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="9" column="5">
+      <widget class="QLabel" name="label_7">
+       <property name="toolTip">
+        <string>Water production of this item. Negative values means power consumption.</string>
+       </property>
+       <property name="text">
+        <string>Water production</string>
+       </property>
+      </widget>
      </item>
-     <item row="9" column="2">
+     <item row="9" column="3">
       <layout class="QHBoxLayout" name="stylesButtonsHorizontalLayout"/>
      </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_19">
+     <item row="14" column="6">
+      <widget class="QSpinBox" name="happiness">
        <property name="toolTip">
-        <string>Restrict this building to certain Art Styles. </string>
-       </property>
-       <property name="text">
-        <string>Styles</string>
+        <string>The effect on happiness around this building.	</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="2">
+     <item row="11" column="3">
       <widget class="QLineEdit" name="tags">
        <property name="toolTip">
         <string>Multiple tags for searching this item ingame. Seperate tags with a comma.</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label_15">
+     <item row="4" column="6">
+      <widget class="QSpinBox" name="fireHazardLevel">
        <property name="toolTip">
-        <string>Multiple tags for searching this item ingame. Seperate tags with a comma.</string>
+        <string>Fire hazard rate this building produces or prevents (police station)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_20">
+       <property name="toolTip">
+        <string>Restrict this building to a certain wealth level. </string>
        </property>
        <property name="text">
-        <string>Tags</string>
+        <string>Wealth</string>
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="label_16">
-       <property name="toolTip">
-        <string>Restrict this building to spawn only in the given biomes. Must correspond to a biome defined in resources/data/TerrainGen.json. Values must be commaseperated</string>
-       </property>
-       <property name="text">
-        <string>Biomes</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="2">
-      <widget class="QLineEdit" name="biomes">
-       <property name="toolTip">
-        <string>Restrict this building to spawn only in the given biomes. Must correspond to a biome defined in resources/data/TerrainGen.json. Values must be commaseperated</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="label_13">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family:'-apple-system','BlinkMacSystemFont','Segoe UI','Helvetica','Arial','sans-serif','Apple Color Emoji','Segoe UI Emoji'; font-size:16px; color:#24292e; background-color:#ffffff;&quot;&gt;tileID of the item that should be drawn on ground below sprite instead of terrain (grass, concrete, ...). When more than one tileID is supplied, a random ground decoration is chosen from the list on placement. Must be a tileID with tileType GroundDecoration.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:'-apple-system','BlinkMacSystemFont','Segoe UI','Helvetica','Arial','sans-serif','Apple Color Emoji','Segoe UI Emoji'; font-size:16px; color:#24292e; background-color:#ffffff;&quot;&gt;Valuesmust be commaseperated.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>GroundDecoration</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="2">
-      <widget class="QLineEdit" name="groundDecoration">
-       <property name="toolTip">
-        <string>tileID of the item that should be drawn on ground below sprite instead of terrain (grass, concrete, ...). When more than one tileID is supplied, a random ground decoration is chosen from the list on placement. Must be a tileID with tileType GroundDecoration.
+     <item row="13" column="3">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QPushButton" name="groundDecorationButton">
+         <property name="text">
+          <string>Edit</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="groundDecoration">
+         <property name="toolTip">
+          <string>tileID of the item that should be drawn on ground below sprite instead of terrain (grass, concrete, ...). When more than one tileID is supplied, a random ground decoration is chosen from the list on placement. Must be a tileID with tileType GroundDecoration.
 Valuesmust be commaseperated.</string>
-       </property>
-      </widget>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/TileSetDataUI.ui
+++ b/src/TileSetDataUI.ui
@@ -98,6 +98,9 @@
        <property name="toolTip">
         <string>If clip_rect (width and height) is used, the offset in the spritesheet where the clipping should start</string>
        </property>
+       <property name="minimum">
+        <number>-99</number>
+       </property>
       </widget>
      </item>
      <item>

--- a/src/TileSetDataUI.ui
+++ b/src/TileSetDataUI.ui
@@ -15,7 +15,7 @@
    <string>Form</string>
   </property>
   <property name="toolTip">
-   <string>Height of this element or of one tile, if the image contains multiple tiles in a tileset.</string>
+   <string/>
   </property>
   <layout class="QFormLayout" name="formLayout">
    <property name="horizontalSpacing">
@@ -263,7 +263,7 @@
         <x>0</x>
         <y>0</y>
         <width>710</width>
-        <height>307</height>
+        <height>322</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -322,7 +322,7 @@
        </property>
        <property name="icon">
         <iconset>
-         <normaloff>../images/iconFolder.png</normaloff>../images/iconFolder.png</iconset>
+         <normaloff>C:/Users/lisaw/.designer/images/iconFolder.png</normaloff>C:/Users/lisaw/.designer/images/iconFolder.png</iconset>
        </property>
       </widget>
      </item>
@@ -336,7 +336,7 @@
        </property>
        <property name="icon">
         <iconset>
-         <normaloff>../images/iconX.png</normaloff>../images/iconX.png</iconset>
+         <normaloff>C:/Users/lisaw/.designer/images/iconX.png</normaloff>C:/Users/lisaw/.designer/images/iconX.png</iconset>
        </property>
       </widget>
      </item>

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -22,6 +22,10 @@ int main(int argc, char **argv)
     if (!ui.loadFile("resources/data/TileData.json"))
         return -1;
 
+    if (!ui.loadBiomeData("resources/data/TerrainGen.json"))
+      return -1;
+    
+
     ui.show();
 
     return app.exec();


### PR DESCRIPTION
- now tiles with count == 1 and offset == 1 can be selected in tiledata edtior
- scaling now works for all buildings
- adjusted min / max values for certain fields
- when resizing the window, the tile preview now correctly resizes instead of the description box (which is fixed now as intended)
- add an "Edit" button for ground decoration which will spawn a new dialog where you can see all available ground decoration tileIDs in a list and add / remove them to the list
- add an "Edit" button for biomes which will spawn a new dialog where you can see all available biomes configured in TerrainGen.json in a list and add / remove them to the list
- added "Add All Items" and "Clear All Items" buttons to the List Selection dialog